### PR TITLE
[MRM-1833] Nullpointer when browsing artifacts which have dependencies with scope "import"

### DIFF
--- a/archiva-modules/plugins/maven2-repository/src/main/java/org/apache/archiva/metadata/repository/storage/maven2/RepositoryModelResolver.java
+++ b/archiva-modules/plugins/maven2-repository/src/main/java/org/apache/archiva/metadata/repository/storage/maven2/RepositoryModelResolver.java
@@ -212,7 +212,8 @@ public class RepositoryModelResolver
     @Override
     public ModelResolver newCopy()
     {
-        return new RepositoryModelResolver( basedir, pathTranslator );
+        return new RepositoryModelResolver( managedRepository,  pathTranslator, wagonFactory, remoteRepositories, 
+                                            networkProxyMap, targetRepository );
     }
 
     // FIXME: we need to do some refactoring, we cannot re-use the proxy components of archiva-proxy in maven2-repository


### PR DESCRIPTION
Use the full constructor to create the clone, as resolveModel expects
remoteRepositories to be not null
