### PR TITLE
MRM-1311: Added Loggers to core consumers

### DIFF
--- a/archiva-modules/archiva-base/archiva-consumers/archiva-core-consumers/src/main/java/org/apache/archiva/consumers/core/ArtifactMissingChecksumsConsumer.java
+++ b/archiva-modules/archiva-base/archiva-consumers/archiva-core-consumers/src/main/java/org/apache/archiva/consumers/core/ArtifactMissingChecksumsConsumer.java
@@ -32,6 +32,8 @@ import org.apache.archiva.redback.components.registry.Registry;
 import org.apache.archiva.redback.components.registry.RegistryListener;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -54,6 +56,9 @@ public class ArtifactMissingChecksumsConsumer
     // it's prototype bean so we assume configuration won't change during a run
     //, RegistryListener
 {
+
+    private Logger log = LoggerFactory.getLogger( ArtifactMissingChecksumsConsumer.class );
+
     private String id = "create-missing-checksums";
 
     private String description = "Create Missing and/or Fix Invalid Checksums (.sha1, .md5)";
@@ -169,11 +174,13 @@ public class ArtifactMissingChecksumsConsumer
                 if ( !checksum.isValidChecksum( checksumAlgorithm[0] ) )
                 {
                     checksum.fixChecksums( checksumAlgorithm );
+                    log.info( "Fixed checksum file {}", checksumFile.getAbsolutePath() );
                     triggerConsumerInfo( "Fixed checksum file " + checksumFile.getAbsolutePath() );
                 }
             }
             catch ( IOException e )
             {
+                log.error( "Cannot calculate checksum for file {} :", checksumFile, e );
                 triggerConsumerError( TYPE_CHECKSUM_CANNOT_CALC, "Cannot calculate checksum for file " + checksumFile +
                     ": " + e.getMessage() );
             }
@@ -184,16 +191,19 @@ public class ArtifactMissingChecksumsConsumer
             try
             {
                 checksum.createChecksum( checksumAlgorithm[0] );
+                log.info( "Created missing checksum file {}", checksumFile.getAbsolutePath() ); 
                 triggerConsumerInfo( "Created missing checksum file " + checksumFile.getAbsolutePath() );
             }
             catch ( IOException e )
             {
+                log.error( "Cannot create checksum for file {} :", checksumFile, e );
                 triggerConsumerError( TYPE_CHECKSUM_CANNOT_CREATE, "Cannot create checksum for file " + checksumFile +
                     ": " + e.getMessage() );
             }
         }
         else
         {
+            log.warn( "Checksum file {} is not a file. ", checksumFile.getAbsolutePath() );
             triggerConsumerWarning( TYPE_CHECKSUM_NOT_FILE,
                                     "Checksum file " + checksumFile.getAbsolutePath() + " is not a file." );
         }

--- a/archiva-modules/archiva-base/archiva-consumers/archiva-core-consumers/src/main/java/org/apache/archiva/consumers/core/AutoRemoveConsumer.java
+++ b/archiva-modules/archiva-base/archiva-consumers/archiva-core-consumers/src/main/java/org/apache/archiva/consumers/core/AutoRemoveConsumer.java
@@ -30,6 +30,8 @@ import org.apache.archiva.redback.components.registry.Registry;
 import org.apache.archiva.redback.components.registry.RegistryListener;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -49,6 +51,9 @@ public class AutoRemoveConsumer
     extends AbstractMonitoredConsumer
     implements KnownRepositoryContentConsumer, RegistryListener
 {
+
+    private Logger log = LoggerFactory.getLogger( AutoRemoveConsumer.class );
+
     /**
      * default-value="auto-remove"
      */
@@ -138,6 +143,7 @@ public class AutoRemoveConsumer
         File file = new File( this.repositoryDir, path );
         if ( file.exists() )
         {
+            log.info( "(Auto) Removing File: {}", file.getAbsolutePath() );
             triggerConsumerInfo( "(Auto) Removing File: " + file.getAbsolutePath() );
             file.delete();
         }

--- a/archiva-modules/archiva-base/archiva-consumers/archiva-core-consumers/src/main/java/org/apache/archiva/consumers/core/AutoRenameConsumer.java
+++ b/archiva-modules/archiva-base/archiva-consumers/archiva-core-consumers/src/main/java/org/apache/archiva/consumers/core/AutoRenameConsumer.java
@@ -26,6 +26,8 @@ import org.apache.archiva.consumers.KnownRepositoryContentConsumer;
 import org.apache.commons.io.FileUtils;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,6 +49,8 @@ public class AutoRenameConsumer
     extends AbstractMonitoredConsumer
     implements KnownRepositoryContentConsumer
 {
+    private Logger log = LoggerFactory.getLogger( AutoRenameConsumer.class ); 
+
     private String id = "auto-rename";
 
     private String description = "Automatically rename common artifact mistakes.";
@@ -149,12 +153,14 @@ public class AutoRenameConsumer
                     }
                     catch ( IOException e )
                     {
+                        log.warn( "Unable to rename {} to {} :", path, correctedPath, e );
                         triggerConsumerWarning( RENAME_FAILURE, "Unable to rename " + path + " to " + correctedPath +
                             ": " + e.getMessage() );
                     }
                 }
             }
 
+            log.info( "(Auto) Removing File: {} ", file.getAbsolutePath() );
             triggerConsumerInfo( "(Auto) Removing File: " + file.getAbsolutePath() );
             file.delete();
         }

--- a/archiva-modules/archiva-base/archiva-consumers/archiva-core-consumers/src/main/java/org/apache/archiva/consumers/core/MetadataUpdaterConsumer.java
+++ b/archiva-modules/archiva-base/archiva-consumers/archiva-core-consumers/src/main/java/org/apache/archiva/consumers/core/MetadataUpdaterConsumer.java
@@ -219,22 +219,26 @@ public class MetadataUpdaterConsumer
         }
         catch ( LayoutException e )
         {
+            log.warn( "Unable to convert path [{}] to an internal project reference: ", path, e );
             triggerConsumerWarning( TYPE_METADATA_BAD_INTERNAL_REF,
                                     "Unable to convert path [" + path + "] to an internal project reference: "
                                         + e.getMessage() );
         }
         catch ( RepositoryMetadataException e )
         {
+            log.error( "Unable to write project metadat for artifact [{}]:", path, e );
             triggerConsumerError( TYPE_METADATA_WRITE_FAILURE,
                                   "Unable to write project metadata for artifact [" + path + "]: " + e.getMessage() );
         }
         catch ( IOException e )
         {
+            log.warn( "Project metadata not written due to IO warning: ", e );
             triggerConsumerWarning( TYPE_METADATA_IO,
                                     "Project metadata not written due to IO warning: " + e.getMessage() );
         }
         catch ( ContentNotFoundException e )
         {
+            log.warn( "Project metadata not written because no versions were found to update: ", e );
             triggerConsumerWarning( TYPE_METADATA_IO,
                                     "Project metadata not written because no versions were found to update: "
                                         + e.getMessage() );
@@ -266,22 +270,26 @@ public class MetadataUpdaterConsumer
         }
         catch ( LayoutException e )
         {
+            log.warn( "Unable to convert path [{}] to an internal version reference: ", path, e );
             triggerConsumerWarning( TYPE_METADATA_BAD_INTERNAL_REF,
                                     "Unable to convert path [" + path + "] to an internal version reference: "
                                         + e.getMessage() );
         }
         catch ( RepositoryMetadataException e )
         {
+            log.error( "Unable to write version metadata for artifact [{}]: ", path, e ); 
             triggerConsumerError( TYPE_METADATA_WRITE_FAILURE,
                                   "Unable to write version metadata for artifact [" + path + "]: " + e.getMessage() );
         }
         catch ( IOException e )
         {
+            log.warn( "Version metadata not written due to IO warning: ", e );
             triggerConsumerWarning( TYPE_METADATA_IO,
                                     "Version metadata not written due to IO warning: " + e.getMessage() );
         }
         catch ( ContentNotFoundException e )
         {
+            log.warn( "Version metadata not written because no versions were found to update: ", e ); 
             triggerConsumerWarning( TYPE_METADATA_IO,
                                     "Version metadata not written because no versions were found to update: "
                                         + e.getMessage() );

--- a/archiva-modules/archiva-base/archiva-consumers/archiva-core-consumers/src/main/java/org/apache/archiva/consumers/core/ValidateChecksumConsumer.java
+++ b/archiva-modules/archiva-base/archiva-consumers/archiva-core-consumers/src/main/java/org/apache/archiva/consumers/core/ValidateChecksumConsumer.java
@@ -31,6 +31,8 @@ import org.codehaus.plexus.digest.Digester;
 import org.codehaus.plexus.digest.DigesterException;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -52,6 +54,8 @@ public class ValidateChecksumConsumer
     extends AbstractMonitoredConsumer
     implements KnownRepositoryContentConsumer
 {
+    private Logger log = LoggerFactory.getLogger( ValidateChecksumConsumer.class );
+
     private static final String NOT_VALID_CHECKSUM = "checksum-not-valid";
 
     private static final String CHECKSUM_NOT_FOUND = "checksum-not-found";
@@ -143,20 +147,24 @@ public class ValidateChecksumConsumer
         {
             if ( !checksum.isValidChecksum( checksumFile ) )
             {
+                log.warn( "The checksum for {} is invalid.", checksumFile );
                 triggerConsumerWarning( NOT_VALID_CHECKSUM, "The checksum for " + checksumFile + " is invalid." );
             }
         }
         catch ( FileNotFoundException e )
         {
+            log.error( "File not found during checksum validation: ", e );
             triggerConsumerError( CHECKSUM_NOT_FOUND, "File not found during checksum validation: " + e.getMessage() );
         }
         catch ( DigesterException e )
         {
+            log.error( "Digester failure during checksum validation on {}", checksumFile );
             triggerConsumerError( CHECKSUM_DIGESTER_FAILURE,
                                   "Digester failure during checksum validation on " + checksumFile );
         }
         catch ( IOException e )
         {
+            log.error( "Checksum I/O error during validation on {}", checksumFile );
             triggerConsumerError( CHECKSUM_IO_ERROR, "Checksum I/O error during validation on " + checksumFile );
         }
     }


### PR DESCRIPTION
This pull adds loggers and log messages to core consumers, leaving the unused ConsumerMonitor notifications in place. See MRM-1311 for more details.
