### PR TITLE
Specify using separate caches for different data items (users, keys, namespaces)

### DIFF
--- a/archiva-modules/archiva-web/archiva-webapp/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/archiva-modules/archiva-web/archiva-webapp/src/main/webapp/WEB-INF/applicationContext.xml
@@ -193,7 +193,7 @@
     <property name="eternal" value="false"/>
     <property name="maxElementsInMemory" value="1000"/>
     <property name="memoryEvictionPolicy" value="LRU"/>
-    <property name="name" value="usersCache"/>
+    <property name="name" value="keys"/>
     <property name="timeToIdleSeconds" value="1800"/>
     <property name="timeToLiveSeconds" value="14400"/>
   </bean>
@@ -296,7 +296,7 @@
     <property name="eternal" value="false"/>
     <property name="maxElementsInMemory" value="1000"/>
     <property name="memoryEvictionPolicy" value="LRU"/>
-    <property name="name" value="usersCache"/>
+    <property name="name" value="namespaces"/>
     <property name="timeToIdleSeconds" value="600"/>
     <property name="timeToLiveSeconds" value="600"/>
   </bean>


### PR DESCRIPTION
applicationContext.xml contains incorrect configuration for two caches (cache#keys and cache#namespaces).
Configurations for these caches (together with cache#users) share the same name "usersCache", thus in fact the single cache instance is used instead of three different.
This may cause the following problems:
* incorrect timings for cache resfreshing,
* ClassCastException in case of adding items (users, repositories, ...) with the same name.