### PR TITLE
Add alphabetical ordering to the blacklist and whitelist

### DIFF
--- a/archiva-modules/archiva-web/archiva-webapp/src/main/webapp/js/archiva/admin/repository/maven2/proxy-connectors.js
+++ b/archiva-modules/archiva-web/archiva-webapp/src/main/webapp/js/archiva/admin/repository/maven2/proxy-connectors.js
@@ -178,6 +178,7 @@ define("archiva/admin/repository/maven2/proxy-connectors",["jquery","i18n","jque
       var pattern = $("#main-content").find("#blacklist-value").val();
       var tab =  self.proxyConnector.blackListPatterns();
       tab.push(pattern);
+      tab.sort();
       self.proxyConnector.blackListPatterns(tab);
       self.proxyConnector.modified(true);
     }

--- a/archiva-modules/archiva-web/archiva-webapp/src/main/webapp/js/archiva/admin/repository/maven2/proxy-connectors.js
+++ b/archiva-modules/archiva-web/archiva-webapp/src/main/webapp/js/archiva/admin/repository/maven2/proxy-connectors.js
@@ -191,6 +191,7 @@ define("archiva/admin/repository/maven2/proxy-connectors",["jquery","i18n","jque
       var pattern = $("#main-content" ).find("#whitelist-value").val();
       var tab =  self.proxyConnector.whiteListPatterns();
       tab.push(pattern);
+      tab.sort();
       self.proxyConnector.whiteListPatterns(tab);
       self.proxyConnector.modified(true);
 


### PR DESCRIPTION
Currently when managing a lot of entries in the whitelist and blacklist it can get difficult to navigate. It's a lot easier when the ordering is deterministic, thus a quick sort before displaying makes it simple to manage all of your entries.