### PR TITLE
Fix non-deterministic test failures

### DIFF
--- a/archiva-modules/archiva-web/archiva-rest/archiva-rest-services/src/test/java/org/apache/archiva/rest/services/BrowseServiceTest.java
+++ b/archiva-modules/archiva-web/archiva-rest/archiva-rest-services/src/test/java/org/apache/archiva/rest/services/BrowseServiceTest.java
@@ -69,6 +69,7 @@ public class BrowseServiceTest
         throws Exception
     {
         scanRepo( TEST_REPO_ID );
+        waitForScanToComplete( TEST_REPO_ID );
 
         BrowseService browseService = getBrowseService( authorizationHeader, false );
 
@@ -92,6 +93,7 @@ public class BrowseServiceTest
         try
         {
             scanRepo( TEST_REPO_ID );
+            waitForScanToComplete( TEST_REPO_ID );
 
             BrowseService browseService = getBrowseService( authorizationHeader, false );
 
@@ -410,6 +412,7 @@ public class BrowseServiceTest
         throws Exception
     {
         scanRepo( TEST_REPO_ID );
+        waitForScanToComplete( TEST_REPO_ID );
 
         BrowseService browseService = getBrowseService( authorizationHeader, false );
 


### PR DESCRIPTION
Fix some build failures that appear on most builds with java8, and only spuriously on java7:
````
Running org.apache.archiva.rest.services.BrowseServiceTest
Tests run: 21, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 50.76 sec <<< FAILURE! - in org.apache.archiva.rest.services.BrowseServiceTest
metadatainbatchmode(org.apache.archiva.rest.services.BrowseServiceTest)  Time elapsed: 2.955 sec  <<< FAILURE!
java.lang.AssertionError: 

Expecting:
 <{"jenkins_version"="1.486", "author"="alecharp"}>
to contain:
 <[MapEntry[key='buildNumber', value='1']]>
but could not find:
 <[MapEntry[key='buildNumber', value='1']]>

        at org.apache.archiva.rest.services.BrowseServiceTest.metadatainbatchmode(BrowseServiceTest.java:431)
````
