### PR TITLE
Adding default userAgent system property

### DIFF
--- a/archiva-modules/archiva-base/archiva-proxy-common/src/main/java/org/apache/archiva/proxy/common/WagonFactoryRequest.java
+++ b/archiva-modules/archiva-base/archiva-proxy-common/src/main/java/org/apache/archiva/proxy/common/WagonFactoryRequest.java
@@ -29,6 +29,11 @@ import java.util.Map;
  */
 public class WagonFactoryRequest
 {
+
+    public static final String USER_AGENT_SYSTEM_PROPERTY = "archiva.userAgent";
+
+    private static String DEFAULT_USER_AGENT = "Java-Archiva";
+
     /**
      * the protocol to find the Wagon for, which must be prefixed with <code>wagon#</code>, for example
      * <code>wagon#http</code>. <b>to have a wagon supporting ntlm add -ntlm</b>
@@ -37,7 +42,13 @@ public class WagonFactoryRequest
 
     private Map<String, String> headers = new HashMap<>();
 
-    private String userAgent = "Java-Archiva";
+    private String userAgent = DEFAULT_USER_AGENT;
+
+    static {
+        if (System.getProperty(USER_AGENT_SYSTEM_PROPERTY)!=null && !"".equals(System.getProperty(USER_AGENT_SYSTEM_PROPERTY))) {
+            DEFAULT_USER_AGENT=System.getProperty(USER_AGENT_SYSTEM_PROPERTY);
+        }
+    }
 
     private NetworkProxy networkProxy;
 


### PR DESCRIPTION
The default userAgent string used for proxy connections can be configured by
a system property.

See https://issues.apache.org/jira/browse/MRM-1925

Not sure, if a system property is the right thing here, or if the central configuration service should be used. If the latter, please provide some hints how to put that into the central configuration.