### PR TITLE
Remove slash from remote repository check url

### DIFF
--- a/archiva-modules/archiva-web/archiva-rest/archiva-rest-services/src/main/java/org/apache/archiva/rest/services/DefaultRemoteRepositoriesService.java
+++ b/archiva-modules/archiva-web/archiva-rest/archiva-rest-services/src/main/java/org/apache/archiva/rest/services/DefaultRemoteRepositoriesService.java
@@ -201,7 +201,8 @@ public class DefaultRemoteRepositoriesService
             wagon.connect( new Repository( remoteRepository.getId(), remoteRepository.getUrl() ), proxyInfo );
 
             // we only check connectivity as remote repo can be empty
-            wagon.getFileList( "/" );
+            // MRM-1909: Wagon implementation appends a slash already
+            wagon.getFileList( "" );
 
             return Boolean.TRUE;
         }

--- a/archiva-modules/archiva-web/archiva-rest/archiva-rest-services/src/test/java/org/apache/archiva/rest/services/RemoteRepositoriesServiceTest.java
+++ b/archiva-modules/archiva-web/archiva-rest/archiva-rest-services/src/test/java/org/apache/archiva/rest/services/RemoteRepositoriesServiceTest.java
@@ -146,6 +146,21 @@ public class RemoteRepositoriesServiceTest
 
     }
 
+    @Test
+    public void checkRemoteConnectivity()
+            throws Exception {
+        RemoteRepositoriesService service = getRemoteRepositoriesService();
+
+        WebClient.client(service).header("Authorization", authorizationHeader);
+
+        int initialSize = service.getRemoteRepositories().size();
+
+        service.addRemoteRepository(getRemoteRepository());
+
+        assertTrue(service.checkRemoteConnectivity("id-new"));
+
+    }
+
     RemoteRepository getRemoteRepository()
     {
         return new RemoteRepository( "id-new", "new one", "http://foo.com", "default", "foo", "foopassword", 120,


### PR DESCRIPTION
Removes additional '/' character from the URL used to check the remote repositories.

Fixes https://issues.apache.org/jira/browse/MRM-1909
