### PR TITLE
[MRM-1928] Use applicationUrl setting in HTTP redirects

### DIFF
--- a/archiva-modules/archiva-web/archiva-webdav/src/main/java/org/apache/archiva/webdav/ArchivaDavResourceFactory.java
+++ b/archiva-modules/archiva-web/archiva-webdav/src/main/java/org/apache/archiva/webdav/ArchivaDavResourceFactory.java
@@ -47,7 +47,6 @@ import org.apache.archiva.model.ArchivaRepositoryMetadata;
 import org.apache.archiva.model.ArtifactReference;
 import org.apache.archiva.policies.ProxyDownloadException;
 import org.apache.archiva.proxy.model.RepositoryProxyConnectors;
-import org.apache.archiva.proxy.model.ProxyFetchResult;
 import org.apache.archiva.redback.authentication.AuthenticationException;
 import org.apache.archiva.redback.authentication.AuthenticationResult;
 import org.apache.archiva.redback.authorization.AuthorizationException;
@@ -577,8 +576,7 @@ public class ArchivaDavResourceFactory
             String path = e.getPath();
             log.debug( "Relocation to {}", path );
 
-            throw new BrowserRedirectException( contextPath + ( StringUtils.startsWith( path, "/" ) ? "" : "/" ) + path,
-                                                e.getRelocationType() );
+            throw new BrowserRedirectException( addHrefPrefix( contextPath, path ), e.getRelocationType() );
         }
         catch ( XMLException e )
         {
@@ -933,6 +931,16 @@ public class ArchivaDavResourceFactory
             throw new DavException( HttpServletResponse.SC_NO_CONTENT );
         }
         return archivaLocator;
+    }
+
+    private String addHrefPrefix( String contextPath, String path ) {
+        String prefix = archivaConfiguration.getConfiguration().getWebapp().getUi().getApplicationUrl();
+        if (prefix == null || prefix.isEmpty()) {
+            prefix = contextPath;
+        }
+        return prefix + ( StringUtils.startsWith( path, "/" ) ? "" :
+                        ( StringUtils.endsWith( prefix, "/" ) ? "" : "/" ) )
+                      + path;
     }
 
     private static class LogicalResource

--- a/archiva-modules/archiva-web/archiva-webdav/src/test/java/org/apache/archiva/webdav/AbstractRepositoryServletProxiedMetadataTestCase.java
+++ b/archiva-modules/archiva-web/archiva-webdav/src/test/java/org/apache/archiva/webdav/AbstractRepositoryServletProxiedMetadataTestCase.java
@@ -62,46 +62,6 @@ public abstract class AbstractRepositoryServletProxiedMetadataTestCase
         return response.getContentAsString();
     }
 
-    protected String createVersionMetadata( String groupId, String artifactId, String version )
-    {
-        return createVersionMetadata( groupId, artifactId, version, null, null, null );
-    }
-
-    protected String createVersionMetadata( String groupId, String artifactId, String version, String timestamp,
-                                          String buildNumber, String lastUpdated )
-    {
-        StringBuilder buf = new StringBuilder();
-
-        buf.append( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n" );
-        buf.append( "<metadata>\n" );
-        buf.append( "  <groupId>" ).append( groupId ).append( "</groupId>\n" );
-        buf.append( "  <artifactId>" ).append( artifactId ).append( "</artifactId>\n" );
-        buf.append( "  <version>" ).append( version ).append( "</version>\n" );
-
-        boolean hasSnapshot = StringUtils.isNotBlank( timestamp ) || StringUtils.isNotBlank( buildNumber );
-        boolean hasLastUpdated = StringUtils.isNotBlank( lastUpdated );
-
-        if ( hasSnapshot || hasLastUpdated )
-        {
-            buf.append( "  <versioning>\n" );
-            if ( hasSnapshot )
-            {
-                buf.append( "    <snapshot>\n" );
-                buf.append( "      <buildNumber>" ).append( buildNumber ).append( "</buildNumber>\n" );
-                buf.append( "      <timestamp>" ).append( timestamp ).append( "</timestamp>\n" );
-                buf.append( "    </snapshot>\n" );
-            }
-            if ( hasLastUpdated )
-            {
-                buf.append( "    <lastUpdated>" ).append( lastUpdated ).append( "</lastUpdated>\n" );
-            }
-            buf.append( "  </versioning>\n" );
-        }
-        buf.append( "</metadata>" );
-
-        return buf.toString();
-    }
-
     protected String createProjectMetadata( String groupId, String artifactId, String latest, String release,
                                           String[] versions )
     {

--- a/archiva-modules/archiva-web/archiva-webdav/src/test/java/org/apache/archiva/webdav/AbstractRepositoryServletTestCase.java
+++ b/archiva-modules/archiva-web/archiva-webdav/src/test/java/org/apache/archiva/webdav/AbstractRepositoryServletTestCase.java
@@ -75,6 +75,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * AbstractRepositoryServletTestCase
@@ -178,6 +179,36 @@ public abstract class AbstractRepositoryServletTestCase
 
         unauthenticatedRepositoryServlet.init( mockServletConfig );
 
+    }
+
+    protected String createVersionMetadata(String groupId, String artifactId, String version) {
+        return createVersionMetadata(groupId, artifactId, version, null, null, null);
+    }
+
+    protected String createVersionMetadata(String groupId, String artifactId, String version, String timestamp, String buildNumber, String lastUpdated) {
+        StringBuilder buf = new StringBuilder();
+        buf.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n");
+        buf.append("<metadata>\n");
+        buf.append("  <groupId>").append(groupId).append("</groupId>\n");
+        buf.append("  <artifactId>").append(artifactId).append("</artifactId>\n");
+        buf.append("  <version>").append(version).append("</version>\n");
+        boolean hasSnapshot = StringUtils.isNotBlank(timestamp) || StringUtils.isNotBlank(buildNumber);
+        boolean hasLastUpdated = StringUtils.isNotBlank(lastUpdated);
+        if (hasSnapshot || hasLastUpdated) {
+            buf.append("  <versioning>\n");
+            if (hasSnapshot) {
+                buf.append("    <snapshot>\n");
+                buf.append("      <buildNumber>").append(buildNumber).append("</buildNumber>\n");
+                buf.append("      <timestamp>").append(timestamp).append("</timestamp>\n");
+                buf.append("    </snapshot>\n");
+            }
+            if (hasLastUpdated) {
+                buf.append("    <lastUpdated>").append(lastUpdated).append("</lastUpdated>\n");
+            }
+            buf.append("  </versioning>\n");
+        }
+        buf.append("</metadata>");
+        return buf.toString();
     }
 
 


### PR DESCRIPTION
Make use of webapp application URL setting when constructing the HTTP
Location header within redirect responses, which allows clients to
follow them when Archiva runs behind HTTP reverse proxies.