### PR TITLE
[MRM-2011] make test less linux specific

### DIFF
--- a/archiva-modules/archiva-base/archiva-checksum/src/main/java/org/apache/archiva/checksum/Checksum.java
+++ b/archiva-modules/archiva-base/archiva-checksum/src/main/java/org/apache/archiva/checksum/Checksum.java
@@ -19,12 +19,7 @@ package org.apache.archiva.checksum;
  * under the License.
  */
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -108,13 +103,13 @@ public class Checksum
         if (this.result == null || this.result.length==0) {
             finish();
         }
-        return md.isEqual( this.result, cmp );
+        return MessageDigest.isEqual( this.result, cmp );
     }
 
     public boolean compare(String hexString) {
         if (this.result == null || this.result.length==0) {
             finish();
         }
-        return md.isEqual(this.result, Hex.decode( hexString ));
+        return MessageDigest.isEqual(this.result, Hex.decode( hexString ));
     }
 }

--- a/archiva-modules/archiva-base/archiva-checksum/src/main/java/org/apache/archiva/checksum/ChecksumAlgorithm.java
+++ b/archiva-modules/archiva-base/archiva-checksum/src/main/java/org/apache/archiva/checksum/ChecksumAlgorithm.java
@@ -23,11 +23,8 @@ package org.apache.archiva.checksum;
 import org.apache.commons.io.FilenameUtils;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/archiva-modules/archiva-base/archiva-checksum/src/main/java/org/apache/archiva/checksum/ChecksumUtil.java
+++ b/archiva-modules/archiva-base/archiva-checksum/src/main/java/org/apache/archiva/checksum/ChecksumUtil.java
@@ -19,7 +19,6 @@ package org.apache.archiva.checksum;
  * under the License.
  */
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;

--- a/archiva-modules/archiva-base/archiva-checksum/src/main/java/org/apache/archiva/checksum/ChecksummedFile.java
+++ b/archiva-modules/archiva-base/archiva-checksum/src/main/java/org/apache/archiva/checksum/ChecksummedFile.java
@@ -133,7 +133,7 @@ public class ChecksummedFile
     {
         for ( String ext : checksumAlgorithm.getExt( ) )
         {
-            Path file = referenceFile.resolveSibling( referenceFile.getFileName( ) + "." + checksumAlgorithm.getExt( ) );
+            Path file = referenceFile.resolveSibling( referenceFile.getFileName( ) + "." + ext );
             if ( Files.exists( file ) )
             {
                 return file;
@@ -340,7 +340,7 @@ public class ChecksummedFile
 
     private void writeChecksumFile( Path checksumFile, Charset encoding, String checksumHex )
     {
-        FileUtils.writeStringToFile( checksumFile, FILE_ENCODING, checksumHex + "  " + referenceFile.getFileName( ).toString( ) );
+        FileUtils.writeStringToFile( checksumFile, encoding, checksumHex + "  " + referenceFile.getFileName( ).toString( ) );
     }
 
     private boolean isValidChecksumPattern( String filename, String path )

--- a/archiva-modules/archiva-base/archiva-checksum/src/test/java/org/apache/archiva/checksum/AbstractChecksumTestCase.java
+++ b/archiva-modules/archiva-base/archiva-checksum/src/test/java/org/apache/archiva/checksum/AbstractChecksumTestCase.java
@@ -19,7 +19,6 @@ package org.apache.archiva.checksum;
  * under the License.
  */
 
-import junit.framework.TestCase;
 import org.apache.archiva.common.utils.FileUtils;
 import org.apache.archiva.test.utils.ArchivaBlockJUnit4ClassRunner;
 import org.junit.runner.RunWith;
@@ -28,6 +27,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
  * AbstractChecksumTestCase
@@ -36,11 +38,12 @@ import java.nio.file.Paths;
  */
 @RunWith( ArchivaBlockJUnit4ClassRunner.class )
 public abstract class AbstractChecksumTestCase
-    extends TestCase
 {
+    @Rule public TestName name = new TestName();
+
     public Path getTestOutputDir()
     {
-        Path dir = Paths.get( FileUtils.getBasedir(), "target/test-output/" + getName() );
+        Path dir = Paths.get( FileUtils.getBasedir(), "target/test-output/" + name.getMethodName() );
         if ( !Files.exists(dir))
         {
             try
@@ -49,7 +52,7 @@ public abstract class AbstractChecksumTestCase
             }
             catch ( IOException e )
             {
-                fail( "Unable to create test output directory: " + dir.toAbsolutePath() );
+                Assert.fail( "Unable to create test output directory: " + dir.toAbsolutePath() );
             }
         }
         return dir;
@@ -61,7 +64,7 @@ public abstract class AbstractChecksumTestCase
         Path file = dir.resolve(filename );
         if ( !Files.exists(file))
         {
-            fail( "Test Resource does not exist: " + file.toAbsolutePath() );
+            Assert.fail( "Test Resource does not exist: " + file.toAbsolutePath() );
         }
         return file;
     }

--- a/archiva-modules/archiva-base/archiva-checksum/src/test/java/org/apache/archiva/checksum/ChecksumAlgorithmTest.java
+++ b/archiva-modules/archiva-base/archiva-checksum/src/test/java/org/apache/archiva/checksum/ChecksumAlgorithmTest.java
@@ -19,12 +19,11 @@ package org.apache.archiva.checksum;
  * under the License.
  */
 
-import junit.framework.TestCase;
 import org.apache.archiva.test.utils.ArchivaBlockJUnit4ClassRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import java.nio.file.Paths;
+import org.junit.Assert;
 
 /**
  * ChecksumAlgorithmTest
@@ -33,20 +32,19 @@ import java.nio.file.Paths;
  */
 @RunWith( ArchivaBlockJUnit4ClassRunner.class )
 public class ChecksumAlgorithmTest
-    extends TestCase
 {
     @Test
     public void testGetHashByExtensionSha1()
     {
-        assertEquals( ChecksumAlgorithm.SHA1, ChecksumAlgorithm.getByExtension( Paths.get( "something.jar.sha1" ) ) );
-        assertEquals( ChecksumAlgorithm.SHA1, ChecksumAlgorithm.getByExtension( Paths.get( "OTHER.JAR.SHA1" ) ) );
+        Assert.assertEquals( ChecksumAlgorithm.SHA1, ChecksumAlgorithm.getByExtension( Paths.get( "something.jar.sha1" ) ) );
+        Assert.assertEquals( ChecksumAlgorithm.SHA1, ChecksumAlgorithm.getByExtension( Paths.get( "OTHER.JAR.SHA1" ) ) );
     }
     
     @Test
     public void testGetHashByExtensionMd5()
     {
-        assertEquals( ChecksumAlgorithm.MD5, ChecksumAlgorithm.getByExtension( Paths.get( "something.jar.md5" ) ) );
-        assertEquals( ChecksumAlgorithm.MD5, ChecksumAlgorithm.getByExtension( Paths.get( "OTHER.JAR.MD5" ) ) );
+        Assert.assertEquals( ChecksumAlgorithm.MD5, ChecksumAlgorithm.getByExtension( Paths.get( "something.jar.md5" ) ) );
+        Assert.assertEquals( ChecksumAlgorithm.MD5, ChecksumAlgorithm.getByExtension( Paths.get( "OTHER.JAR.MD5" ) ) );
     }
 
     @Test
@@ -55,7 +53,7 @@ public class ChecksumAlgorithmTest
         try
         {
             ChecksumAlgorithm.getByExtension( Paths.get( "something.jar" ) );
-            fail( "Expected " + IllegalArgumentException.class.getName() );
+            Assert.fail( "Expected " + IllegalArgumentException.class.getName() );
         }
         catch ( IllegalArgumentException e )
         {

--- a/archiva-modules/archiva-base/archiva-checksum/src/test/java/org/apache/archiva/checksum/ChecksumTest.java
+++ b/archiva-modules/archiva-base/archiva-checksum/src/test/java/org/apache/archiva/checksum/ChecksumTest.java
@@ -23,12 +23,12 @@ import org.apache.archiva.common.utils.FileUtils;
 import org.apache.archiva.test.utils.ArchivaBlockJUnit4ClassRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Assert;
 
 /**
  * ChecksumTest
@@ -46,7 +46,7 @@ public class ChecksumTest
     public void testConstructSha1()
     {
         Checksum checksum = new Checksum( ChecksumAlgorithm.SHA1 );
-        assertEquals( "Checksum.algorithm", checksum.getAlgorithm().getAlgorithm(), ChecksumAlgorithm.SHA1
+        Assert.assertEquals( "Checksum.algorithm", checksum.getAlgorithm().getAlgorithm(), ChecksumAlgorithm.SHA1
             .getAlgorithm() );
     }
 
@@ -54,7 +54,7 @@ public class ChecksumTest
     public void testConstructMd5()
     {
         Checksum checksum = new Checksum( ChecksumAlgorithm.MD5 );
-        assertEquals( "Checksum.algorithm", checksum.getAlgorithm().getAlgorithm(), ChecksumAlgorithm.MD5
+        Assert.assertEquals( "Checksum.algorithm", checksum.getAlgorithm().getAlgorithm(), ChecksumAlgorithm.MD5
             .getAlgorithm() );
     }
 
@@ -65,7 +65,7 @@ public class ChecksumTest
         byte buf[] = ( "You know, I'm sick of following my dreams, man. "
             + "I'm just going to ask where they're going and hook up with 'em later. - Mitch Hedberg" ).getBytes();
         checksum.update( buf, 0, buf.length );
-        assertEquals( "Checksum", "e396119ae0542e85a74759602fd2f81e5d36d762", checksum.getChecksum() );
+        Assert.assertEquals( "Checksum", "e396119ae0542e85a74759602fd2f81e5d36d762", checksum.getChecksum() );
     }
 
     @Test
@@ -84,32 +84,32 @@ public class ChecksumTest
 
         ChecksumUtil.update( checksums, checkFile );
 
-        assertEquals( "Checksum SHA1", "e396119ae0542e85a74759602fd2f81e5d36d762", checksumSha1.getChecksum() );
-        assertEquals( "Checksum MD5", "21c2c5ca87ec018adacb2e2fb3432219", checksumMd5.getChecksum() );
+        Assert.assertEquals( "Checksum SHA1", "e396119ae0542e85a74759602fd2f81e5d36d762", checksumSha1.getChecksum() );
+        Assert.assertEquals( "Checksum MD5", "21c2c5ca87ec018adacb2e2fb3432219", checksumMd5.getChecksum() );
     }
 
     @Test
     public void testUpdateWholeUpdatePartial()
     {
         Checksum checksum = new Checksum( ChecksumAlgorithm.SHA1 );
-        assertEquals( "Checksum unset", UNSET_SHA1, checksum.getChecksum() );
+        Assert.assertEquals( "Checksum unset", UNSET_SHA1, checksum.getChecksum() );
 
         String expected = "066c2cbbc8cdaecb8ff97dcb84502462d6f575f3";
         byte reesepieces[] = "eatagramovabits".getBytes();
         checksum.update( reesepieces, 0, reesepieces.length );
         String actual = checksum.getChecksum();
 
-        assertEquals( "Expected", expected, actual );
+        Assert.assertEquals( "Expected", expected, actual );
 
         // Reset the checksum.
         checksum.reset();
-        assertEquals( "Checksum unset", UNSET_SHA1, checksum.getChecksum() );
+        Assert.assertEquals( "Checksum unset", UNSET_SHA1, checksum.getChecksum() );
 
         // Now parse it again in 3 pieces.
         checksum.update( reesepieces, 0, 5 );
         checksum.update( reesepieces, 5, 5 );
         checksum.update( reesepieces, 10, reesepieces.length - 10 );
 
-        assertEquals( "Expected", expected, actual );
+        Assert.assertEquals( "Expected", expected, actual );
     }
 }

--- a/archiva-modules/archiva-base/archiva-checksum/src/test/java/org/apache/archiva/checksum/ChecksummedFileTest.java
+++ b/archiva-modules/archiva-base/archiva-checksum/src/test/java/org/apache/archiva/checksum/ChecksummedFileTest.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -32,6 +31,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import org.junit.After;
+import org.junit.Assert;
 
 /**
  * ChecksummedFileTest
@@ -54,7 +55,7 @@ public class ChecksummedFileTest
     private static final Charset FILE_ENCODING = Charset.forName( "UTF-8" );
 
 
-    @Before
+    @After
     public void cleanTestDir()
     {
         try
@@ -64,9 +65,9 @@ public class ChecksummedFileTest
         catch ( IOException ex )
         {
             LoggerFactory.getLogger( ChecksummedFileTest.class ).warn( ex.getMessage(), ex );
-        }
+        }        
     }
-
+    
     private Path createTestableJar( String filename )
         throws IOException
     {
@@ -110,7 +111,7 @@ public class ChecksummedFileTest
         ChecksummedFile checksummedFile = new ChecksummedFile( testfile );
         String expectedChecksum = "f42047fe2e177ac04d0df7aa44d408be";
         String actualChecksum = checksummedFile.calculateChecksum( ChecksumAlgorithm.MD5 );
-        assertEquals( expectedChecksum, actualChecksum );
+        Assert.assertEquals( expectedChecksum, actualChecksum );
     }
 
     @Test
@@ -121,7 +122,7 @@ public class ChecksummedFileTest
         ChecksummedFile checksummedFile = new ChecksummedFile( testfile );
         String expectedChecksum = "2bb14b388973351b0a4dfe11d171965f59cc61a1";
         String actualChecksum = checksummedFile.calculateChecksum( ChecksumAlgorithm.SHA1 );
-        assertEquals( expectedChecksum, actualChecksum );
+        Assert.assertEquals( expectedChecksum, actualChecksum );
     }
 
     @Test
@@ -132,10 +133,10 @@ public class ChecksummedFileTest
         ChecksummedFile checksummedFile = new ChecksummedFile( testableJar );
         checksummedFile.writeFile( ChecksumAlgorithm.SHA1 );
         Path hashFile = checksummedFile.getChecksumFile( ChecksumAlgorithm.SHA1 );
-        assertTrue( "ChecksumAlgorithm file should exist.", Files.exists(hashFile) );
+        Assert.assertTrue( "ChecksumAlgorithm file should exist.", Files.exists(hashFile) );
         String hashContents = org.apache.commons.io.FileUtils.readFileToString( hashFile.toFile(), "UTF-8" );
         hashContents = StringUtils.trim( hashContents );
-        assertEquals( "2bb14b388973351b0a4dfe11d171965f59cc61a1  redback-authz-open.jar", hashContents );
+        Assert.assertEquals( "2bb14b388973351b0a4dfe11d171965f59cc61a1  redback-authz-open.jar", hashContents );
     }
 
     @Test
@@ -149,15 +150,15 @@ public class ChecksummedFileTest
         org.apache.commons.io.FileUtils.writeStringToFile( sha1File.toFile(), "sha1sum: redback-authz-open.jar: No such file or directory", "UTF-8" );
 
         ChecksummedFile checksummedFile = new ChecksummedFile( jarFile );
-        assertFalse( "ChecksummedFile.isValid(SHA1) == false",
+        Assert.assertFalse( "ChecksummedFile.isValid(SHA1) == false",
                      checksummedFile.isValidChecksum( ChecksumAlgorithm.SHA1 ) );
 
         UpdateStatusList fixed = checksummedFile.fixChecksums( Arrays.asList( ChecksumAlgorithm.SHA1 ) );
-        assertEquals(1, fixed.getStatusList().size());
-        assertFalse(fixed.getTotalStatus()==UpdateStatus.ERROR);
-        assertTrue( "ChecksummedFile.fixChecksums() == true", fixed.getStatusList().get(0).getValue()==UpdateStatus.UPDATED );
+        Assert.assertEquals(1, fixed.getStatusList().size());
+        Assert.assertFalse(fixed.getTotalStatus()==UpdateStatus.ERROR);
+        Assert.assertTrue( "ChecksummedFile.fixChecksums() == true", fixed.getStatusList().get(0).getValue()==UpdateStatus.UPDATED );
 
-        assertTrue( "ChecksummedFile.isValid(SHA1) == true",
+        Assert.assertTrue( "ChecksummedFile.isValid(SHA1) == true",
                     checksummedFile.isValidChecksum( ChecksumAlgorithm.SHA1 ) );
     }
 
@@ -165,7 +166,7 @@ public class ChecksummedFileTest
     public void testGetChecksumFile()
     {
         ChecksummedFile checksummedFile = new ChecksummedFile( Paths.get( "test.jar" ) );
-        assertEquals( "test.jar.sha1", checksummedFile.getChecksumFile( ChecksumAlgorithm.SHA1 ).getFileName().toString() );
+        Assert.assertEquals( "test.jar.sha1", checksummedFile.getChecksumFile( ChecksumAlgorithm.SHA1 ).getFileName().toString() );
     }
 
     @Test
@@ -175,7 +176,7 @@ public class ChecksummedFileTest
         Path jarFile = createTestableJar( "examples/redback-authz-open.jar", true, false );
 
         ChecksummedFile checksummedFile = new ChecksummedFile( jarFile );
-        assertTrue( "ChecksummedFile.isValid(SHA1)", checksummedFile.isValidChecksum( ChecksumAlgorithm.SHA1 ) );
+        Assert.assertTrue( "ChecksummedFile.isValid(SHA1)", checksummedFile.isValidChecksum( ChecksumAlgorithm.SHA1 ) );
     }
 
     @Test
@@ -189,7 +190,7 @@ public class ChecksummedFileTest
         FileUtils.writeStringToFile( sha1File, FILE_ENCODING, "sha1sum: redback-authz-open.jar: No such file or directory" );
 
         ChecksummedFile checksummedFile = new ChecksummedFile( jarFile );
-        assertFalse( "ChecksummedFile.isValid(SHA1)", checksummedFile.isValidChecksum( ChecksumAlgorithm.SHA1 ) );
+        Assert.assertFalse( "ChecksummedFile.isValid(SHA1)", checksummedFile.isValidChecksum( ChecksumAlgorithm.SHA1 ) );
 
     }
 
@@ -200,7 +201,7 @@ public class ChecksummedFileTest
         Path jarFile = createTestableJar( "examples/redback-authz-open.jar", false, false );
 
         ChecksummedFile checksummedFile = new ChecksummedFile( jarFile );
-        assertFalse( "ChecksummedFile.isValid(SHA1,MD5)", checksummedFile.isValidChecksums(
+        Assert.assertFalse( "ChecksummedFile.isValid(SHA1,MD5)", checksummedFile.isValidChecksums(
             Arrays.asList(ChecksumAlgorithm.SHA1, ChecksumAlgorithm.MD5 ) ) );
 
     }
@@ -212,7 +213,7 @@ public class ChecksummedFileTest
         Path jarFile = createTestableJar( "examples/redback-authz-open.jar", true, true );
 
         ChecksummedFile checksummedFile = new ChecksummedFile( jarFile );
-        assertTrue( "ChecksummedFile.isValid(SHA1,MD5)", checksummedFile.isValidChecksums(
+        Assert.assertTrue( "ChecksummedFile.isValid(SHA1,MD5)", checksummedFile.isValidChecksums(
             Arrays.asList(ChecksumAlgorithm.SHA1, ChecksumAlgorithm.MD5 ) ) );
     }
 
@@ -223,7 +224,7 @@ public class ChecksummedFileTest
         Path jarFile = createTestableJar( "examples/redback-authz-open.jar", true, false );
 
         ChecksummedFile checksummedFile = new ChecksummedFile( jarFile );
-        assertTrue( "ChecksummedFile.isValid(SHA1)", checksummedFile.isValidChecksums(
+        Assert.assertTrue( "ChecksummedFile.isValid(SHA1)", checksummedFile.isValidChecksums(
             Arrays.asList(ChecksumAlgorithm.SHA1, ChecksumAlgorithm.MD5 ) ) );
 
     }
@@ -240,7 +241,7 @@ public class ChecksummedFileTest
         ChecksummedFile checksummedFile = new ChecksummedFile( testfile );
         String s = checksummedFile.parseChecksum( expectedFile, ChecksumAlgorithm.SHA1,
                                                   "servletapi/servletapi/2.4/servletapi-2.4.pom", FILE_ENCODING);
-        assertEquals( "Checksum doesn't match", SERVLETAPI_SHA1, s );
+        Assert.assertEquals( "Checksum doesn't match", SERVLETAPI_SHA1, s );
 
     }
 
@@ -254,7 +255,7 @@ public class ChecksummedFileTest
         ChecksummedFile checksummedFile = new ChecksummedFile( testfile );
         String s = checksummedFile.parseChecksum( expectedFile, ChecksumAlgorithm.SHA1,
                                                   "servletapi/servletapi/2.4/servletapi-2.4.pom", FILE_ENCODING );
-        assertEquals( "Checksum doesn't match", SERVLETAPI_SHA1, s );
+        Assert.assertEquals( "Checksum doesn't match", SERVLETAPI_SHA1, s );
     }
 
     @Test
@@ -267,7 +268,7 @@ public class ChecksummedFileTest
         ChecksummedFile checksummedFile = new ChecksummedFile( testfile );
         String s = checksummedFile.parseChecksum( expectedFile, ChecksumAlgorithm.SHA1,
                                                   "servletapi/servletapi/2.4/servletapi-2.4.pom" , FILE_ENCODING);
-        assertEquals( "Checksum doesn't match", SERVLETAPI_SHA1, s );
+        Assert.assertEquals( "Checksum doesn't match", SERVLETAPI_SHA1, s );
     }
 
     @Test
@@ -282,12 +283,12 @@ public class ChecksummedFileTest
         try
         {
             String s = checksummedFile.parseChecksum( expectedFile, ChecksumAlgorithm.SHA1, "maven-metadata-remote.xml", FILE_ENCODING );
-            assertEquals( "Checksum doesn't match", REMOTE_METADATA_SHA1, s );
+            Assert.assertEquals( "Checksum doesn't match", REMOTE_METADATA_SHA1, s );
         }
         catch ( ChecksumValidationException e )
         {
             e.printStackTrace();
-            fail( "IOException should not occur." );
+            Assert.fail( "IOException should not occur." );
         }
     }
 
@@ -303,12 +304,12 @@ public class ChecksummedFileTest
         try
         {
             String s = checksummedFile.parseChecksum( expectedFile, ChecksumAlgorithm.MD5, "maven-metadata-remote.xml", FILE_ENCODING );
-            assertEquals( "Checksum doesn't match", REMOTE_METADATA_MD5, s );
+            Assert.assertEquals( "Checksum doesn't match", REMOTE_METADATA_MD5, s );
         }
         catch ( ChecksumValidationException e )
         {
             e.printStackTrace();
-            fail( "IOException should not occur." );
+            Assert.fail( "IOException should not occur." );
         }
     }
 }

--- a/archiva-modules/archiva-base/archiva-common/src/main/java/org/apache/archiva/common/utils/PathUtil.java
+++ b/archiva-modules/archiva-base/archiva-common/src/main/java/org/apache/archiva/common/utils/PathUtil.java
@@ -26,8 +26,6 @@ import java.net.URI;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.StringTokenizer;
 import java.util.Vector;
 import java.util.stream.StreamSupport;

--- a/archiva-modules/archiva-base/archiva-common/src/main/java/org/apache/archiva/event/EventHandler.java
+++ b/archiva-modules/archiva-base/archiva-common/src/main/java/org/apache/archiva/event/EventHandler.java
@@ -19,7 +19,6 @@ package org.apache.archiva.event;
  * under the License.
  */
 
-import org.apache.archiva.event.Event;
 
 import java.util.EventListener;
 

--- a/archiva-modules/archiva-base/archiva-common/src/main/java/org/apache/archiva/event/EventManager.java
+++ b/archiva-modules/archiva-base/archiva-common/src/main/java/org/apache/archiva/event/EventManager.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class EventManager implements EventSource
 {
 
-    private static final Logger log = LoggerFactory.getLogger(EventManager.class);
+    private static final Logger LOG = LoggerFactory.getLogger(EventManager.class);
 
     private final ConcurrentHashMap<EventType<? extends Event>, Set<EventHandler>> handlerMap = new ConcurrentHashMap<>();
 
@@ -71,7 +71,7 @@ public class EventManager implements EventSource
                             handler.handle(event);
                         } catch (Exception e) {
                             // We catch all errors from handlers
-                            log.error("An error occured during event handling: {}", e.getMessage(), e);
+                            LOG.error("An error occured during event handling: {}", e.getMessage(), e);
                         }
                     }
             }

--- a/archiva-modules/archiva-base/archiva-common/src/main/java/org/apache/archiva/event/EventType.java
+++ b/archiva-modules/archiva-base/archiva-common/src/main/java/org/apache/archiva/event/EventType.java
@@ -119,7 +119,7 @@ public class EventType<T extends Event> implements Serializable  {
 
 
     private Object writeReplace() throws ObjectStreamException {
-        Deque<String> path = new LinkedList<String>();
+        Deque<String> path = new LinkedList<>();
         EventType<?> t = this;
         while (t != ROOT) {
             path.addFirst(t.name);

--- a/archiva-modules/archiva-base/archiva-common/src/test/java/org/apache/archiva/common/utils/PathUtilTest.java
+++ b/archiva-modules/archiva-base/archiva-common/src/test/java/org/apache/archiva/common/utils/PathUtilTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.apache.commons.io.FilenameUtils;
 
 /**
  * PathUtilTest 
@@ -33,15 +34,16 @@ import java.nio.file.Paths;
 public class PathUtilTest
     extends TestCase
 {
+
     public void testToRelativeWithoutSlash()
     {
-        assertEquals( "path/to/resource.xml", PathUtil.getRelative( "/home/user/foo/repository",
+        assertEquals( FilenameUtils.separatorsToSystem( "path/to/resource.xml" ), PathUtil.getRelative( "/home/user/foo/repository",
                                                                     "/home/user/foo/repository/path/to/resource.xml" ) );
     }
     
     public void testToRelativeWithSlash()
     {
-        assertEquals( "path/to/resource.xml", PathUtil.getRelative( "/home/user/foo/repository/",
+        assertEquals( FilenameUtils.separatorsToSystem( "path/to/resource.xml" ), PathUtil.getRelative( "/home/user/foo/repository/",
                                                                     "/home/user/foo/repository/path/to/resource.xml" ) );
     }
 
@@ -87,7 +89,7 @@ public class PathUtilTest
 
         String path = "path/to/resource.xml";
         String expectedPath = "file:" + workingDirname + "/" + path;
-
+        
         assertEquals( expectedPath, PathUtil.toUrl( expectedPath ) );
     }
 }


### PR DESCRIPTION
Hi @effrafax. This is a little PR to try to get more windows test to pass.

for common it's just rewriting the path for os.

for checksum I try to put temporary folder that take test name instead of null.
On windows deletion is not garantee. Maybe a bug in nio. This may be hard to protect in our base module.  