### PR TITLE
Avoid Jetty's default directory listing settings in web.xml

### DIFF
--- a/archiva-modules/archiva-web/archiva-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/archiva-modules/archiva-web/archiva-webapp/src/main/webapp/WEB-INF/web.xml
@@ -161,7 +161,18 @@
     <servlet-name>CXFServletV2</servlet-name>
     <url-pattern>/api/*</url-pattern>
   </servlet-mapping>
-  
+
+  <!-- Removing dir-listing from Jetty default-servlet -->
+  <servlet>
+    <servlet-name>default</servlet-name>
+    <servlet-class>org.eclipse.jetty.servlet.DefaultServlet</servlet-class>
+    <init-param>
+      <param-name>dirAllowed</param-name>
+      <param-value>false</param-value>
+    </init-param>
+    <load-on-startup>0</load-on-startup>
+  </servlet>
+
   <welcome-file-list>
     <welcome-file>index.html</welcome-file>
   </welcome-file-list>


### PR DESCRIPTION
The directory listing servlet seems not be needed for the default
settings. This change explicitly sets it off in web.xml.
Credis to @jobar for the original change made for Wikimedia.